### PR TITLE
Fix Windows issue with ampersand in the URLs

### DIFF
--- a/opener.js
+++ b/opener.js
@@ -35,6 +35,11 @@ function opener(args, options, callback) {
         //
         // Furthermore, if "cmd /c" double-quoted the first parameter, then "start" will interpret it as a window title,
         // so we need to add a dummy empty-string window title: http://stackoverflow.com/a/154090/3191
+        //
+        // Additionally, on Windows ampersand needs to be escaped when passed to "start"
+        args = args.map(function(value) {
+            return value.replace(/&/g, '^&');
+        });
         args = ["/c", "start", '""'].concat(args);
     }
 


### PR DESCRIPTION
Fixed #9 

Tested in node:

    require('./opener')('http://example.org/?a=1&b=2&c=3')

and in the command line:

    ./opener.js "http://example.org/?a=1&b=2&c=3"

now it opens those URLs correctly. In the command line it's still needed to quote the URL, I think there's no way around it, since Windows is interpreting the ampersand before it passes it to the program, unless you quote the param.