### PR TITLE
Added min flag

### DIFF
--- a/opener.js
+++ b/opener.js
@@ -40,7 +40,7 @@ function opener(args, options, callback) {
         args = args.map(function(value) {
             return value.replace(/&/g, '^&');
         });
-        args = ["/c", "start", '""'].concat(args);
+        args = ["/c", "start", "/MIN", '""'].concat(args);
     }
 
     return childProcess.execFile(command, args, options, callback);


### PR DESCRIPTION
I'm using opener in my program and I notice that every time I use it (I'm on windows 10), I notice a command prompt window flash open and close. Personally it's not very annoying but when I release my app, I don't want my users to see it flash on their screen. So the simple solution is adding the "/MIN" tag onto the start command, which just tells the `start` command to launch its window minimized. After this change, the window is visually unnoticeable.