### PR TITLE
split executable into separate file

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+"use strict";
+
+var opener = require('./')
+
+opener(process.argv.slice(2), function (error) {
+    if (error) {
+        throw error;
+    }
+});

--- a/opener.js
+++ b/opener.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 "use strict";
 
 var childProcess = require("child_process");
@@ -49,12 +47,3 @@ function opener(args, options, callback) {
 // Export `opener` for programmatic access.
 // You might use this to e.g. open a website: `opener("http://google.com")`
 module.exports = opener;
-
-// If we're being called from the command line, just execute, using the command-line arguments.
-if (require.main && require.main.id === module.id) {
-    opener(process.argv.slice(2), function (error) {
-        if (error) {
-            throw error;
-        }
-    });
-}

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
     "license": "(WTFPL OR MIT)",
     "repository": "domenic/opener",
     "main": "opener.js",
-    "bin": "opener.js",
+    "bin": "bin.js",
     "files": [
-        "opener.js"
+        "opener.js",
+        "bin.js"
     ],
     "scripts": {
         "lint": "jshint opener.js"


### PR DESCRIPTION
This patch splits off the executable code into `bin.js`. I was having trouble compiling it with `browserify` as Acorn doesn't like parsing hashbangs in dependencies it seems. Probably a patch release I reckon. Thanks!

---

#### error.log
```txt
❯ npm run bundle

> dat-desktop@1.0.1 bundle /Users/anon/src/datproject/dat-desktop
> browserify --fast --ignore-missing --node --full-paths --exclude=electron -g bindingify app.js > bundle.js

/Users/anon/src/datproject/dat-desktop/node_modules/acorn/dist/acorn.js:2223
    throw err
    ^

SyntaxError: Unexpected character '#' (1:0)
    at Parser.pp$4.raise (/Users/anon/src/datproject/dat-desktop/node_modules/acorn/dist/acorn.js:2221:15)
    at Parser.pp$7.getTokenFromCode (/Users/anon/src/datproject/dat-desktop/node_modules/acorn/dist/acorn.js:2756:10)
    at Parser.pp$7.readToken (/Users/anon/src/datproject/dat-desktop/node_modules/acorn/dist/acorn.js:2477:17)
    at Parser.pp$7.nextToken (/Users/anon/src/datproject/dat-desktop/node_modules/acorn/dist/acorn.js:2468:15)
    at Parser.parse (/Users/anon/src/datproject/dat-desktop/node_modules/acorn/dist/acorn.js:515:10)
    at parse (/Users/anon/src/datproject/dat-desktop/node_modules/acorn/dist/acorn.js:3098:39)
    at module.exports (/Users/anon/src/datproject/dat-desktop/node_modules/falafel/index.js:22:15)
    at DestroyableTransform.flush [as _flush] (/Users/anon/src/datproject/dat-desktop/node_modules/bindingify/index.js:23:18)
    at DestroyableTransform.<anonymous> (/Users/anon/src/datproject/dat-desktop/node_modules/readable-stream/lib/_stream_transform.js:115:49)
    at DestroyableTransform.g (events.js:286:16)

npm ERR! Darwin 15.5.0
npm ERR! argv "/Users/anon/.nvm/versions/node/v6.4.0/bin/node" "/Users/anon/.nvm/versions/node/v6.4.0/bin/npm" "run" "bundle"
npm ERR! node v6.4.0
```