### PR TITLE
Change cmd invocation into cmd.exe (WSL)

### DIFF
--- a/lib/opener.js
+++ b/lib/opener.js
@@ -16,7 +16,7 @@ module.exports = function opener(args, options, callback) {
     var command;
     switch (platform) {
         case "win32": {
-            command = "cmd";
+            command = "cmd.exe";
             break;
         }
         case "darwin": {


### PR DESCRIPTION
A small tweak is still required for it to properly work under WSL (calling `cmd.exe` instead of `cmd`; should not have any impact on Windows itself) 😄