### PR TITLE
GHSL-2020-145: escape ^ character to prevent code injection attacks

### DIFF
--- a/lib/opener.js
+++ b/lib/opener.js
@@ -55,9 +55,9 @@ module.exports = function opener(args, options, callback) {
         // Furthermore, if "cmd /c" double-quoted the first parameter, then "start" will interpret it as a window title,
         // so we need to add a dummy empty-string window title: http://stackoverflow.com/a/154090/3191
         //
-        // Additionally, on Windows ampersand needs to be escaped when passed to "start"
+        // Additionally, on Windows ampersand and caret need to be escaped when passed to "start"
         args = args.map(function (value) {
-            return value.replace(/&/g, "^&");
+            return value.replace(/[&^]/g, "^$&");
         });
         args = ["/c", "start", "\"\""].concat(args);
     }


### PR DESCRIPTION
On Windows, opener does not escape the `^` character which can lead to code injection. For example:

```
const opener = require("opener");
opener(`https://github.com/${user}`);
```

If `${user}` is the string `^&calc`, then on Windows this code will open the (meaningless) url `https://github.com/%5E` in a browser and launch `calc.exe`.

We discussed this privately with the maintainer, who says that this is not a vulnerability because opener's entire purpose is to execute arbitrary commands. 